### PR TITLE
Issue #26 - [C12- Define and throw a dedicated exception instead of using generic]

### DIFF
--- a/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
+++ b/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
@@ -21,6 +21,7 @@ package de.tudarmstadt.ukp.inception.conceptlinking.service;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -117,7 +118,7 @@ public class ConceptLinkingServiceImplTest
             .contains("manatee");
     }
 
-    private void importKnowledgeBase(String resourceName) throws Exception {
+    private void importKnowledgeBase(String resourceName) throws IOException  {
         ClassLoader classLoader = getClass().getClassLoader();
         String fileName = classLoader.getResource(resourceName).getFile();
         try (InputStream is = classLoader.getResourceAsStream(resourceName)) {

--- a/inception-doc/src/test/java/de/tudarmstadt/ukp/inception/doc/GenerateDocumentation.java
+++ b/inception-doc/src/test/java/de/tudarmstadt/ukp/inception/doc/GenerateDocumentation.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.doc;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,7 +39,7 @@ public class GenerateDocumentation
     private static Path asciiDocPath = Paths.get("src", "main", "resources", "META-INF", "asciidoc");
 
 
-    private static List<Path> getAsciiDocs(Path dir) throws Exception
+    private static List<Path> getAsciiDocs(Path dir) throws IOException 
     {
         return Files.list(dir)
                 .filter(Files::isDirectory)

--- a/inception-example-imls-data-majority/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/datamajority/DataMajorityNerRecommenderTest.java
+++ b/inception-example-imls-data-majority/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/datamajority/DataMajorityNerRecommenderTest.java
@@ -55,6 +55,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResu
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.PercentageBasedSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.RecommenderTestHelper;
 
@@ -73,7 +74,7 @@ public class DataMajorityNerRecommenderTest
     }
 
     @Test
-    public void thatTrainingWorks() throws Exception
+    public void thatTrainingWorks() throws IOException, UIMAException, RecommendationException 
     {
         DataMajorityNerRecommender sut = new DataMajorityNerRecommender(recommender);
         List<CAS> casList = loadDevelopmentData();
@@ -86,7 +87,7 @@ public class DataMajorityNerRecommenderTest
     }
 
     @Test
-    public void thatPredictionWorks() throws Exception
+    public void thatPredictionWorks() throws Exception 
     {
         DataMajorityNerRecommender sut = new DataMajorityNerRecommender(recommender);
         List<CAS> casList = loadDevelopmentData();
@@ -111,7 +112,7 @@ public class DataMajorityNerRecommenderTest
     }
 
     @Test
-    public void thatEvaluationWorks() throws Exception
+    public void thatEvaluationWorks() throws IOException, UIMAException, RecommendationException 
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
         DataMajorityNerRecommender sut = new DataMajorityNerRecommender(recommender);
@@ -190,7 +191,7 @@ public class DataMajorityNerRecommenderTest
         return cas;
     }
     @Test
-    public void thatIncrementalNerEvaluationWorks() throws Exception
+    public void thatIncrementalNerEvaluationWorks() throws IOException, UIMAException, RecommendationException 
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 5000, 10);
         DataMajorityNerRecommender sut = new DataMajorityNerRecommender(recommender);

--- a/inception-external-search-elastic/src/test/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProviderTest.java
+++ b/inception-external-search-elastic/src/test/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProviderTest.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.externalsearch.elastic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.Before;
@@ -51,7 +52,7 @@ public class ElasticSearchProviderTest
     }
     
     @Test
-    public void thatQueryWorks() throws Exception
+    public void thatQueryWorks() throws IOException 
     {
         List<ExternalSearchResult> results = sut.executeQuery(repo, traits, "shiny");
         
@@ -61,7 +62,7 @@ public class ElasticSearchProviderTest
     }
     
     @Test
-    public void thatDocumentTextCanBeRetrieved() throws Exception
+    public void thatDocumentTextCanBeRetrieved() throws IOException 
     {
         String documentText = sut.getDocumentText(repo, traits,
                 "common-crawl-en", "TcBhiGABg9im2MD5uAjq");

--- a/inception-external-search-pubannotation/src/test/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/PubAnnotationProviderTest.java
+++ b/inception-external-search-pubannotation/src/test/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/PubAnnotationProviderTest.java
@@ -46,7 +46,7 @@ public class PubAnnotationProviderTest
     }
 
     @Test
-    public void thatQueryWorks() throws Exception
+    public void thatQueryWorks() 
     {
         List<PubAnnotationDocumentHandle> results = sut.query(traits, "binding");
         
@@ -56,7 +56,7 @@ public class PubAnnotationProviderTest
     }
 
     @Test
-    public void thatExecuteQueryWorks() throws Exception
+    public void thatExecuteQueryWorks() 
     {
         List<ExternalSearchResult> results = sut.executeQuery(repo, traits, "binding");
         
@@ -66,7 +66,7 @@ public class PubAnnotationProviderTest
     }
     
     @Test
-    public void thatDocumentTextCanBeRetrieved() throws Exception
+    public void thatDocumentTextCanBeRetrieved() 
     {
         String text = sut.getDocumentText(repo, traits, "PMC", "1064873");
         

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
@@ -28,6 +28,9 @@
           <div class="col-sm-9">
             <input wicket:id="remoteUrl" type="text" class="form-control"></input>
           </div>
+          <div>
+          <input type="button" wicket:id="check" class="btn btn-primary" wicket:message="value:check-connection"></input>
+          </div>
         </div>
       </div>
     </div>

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
@@ -17,14 +17,28 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
+import java.awt.Button;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.feedback.IFeedbackMessageFilter;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.validation.IFormValidator;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.apache.wicket.validation.validator.UrlValidator;
 
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
@@ -64,10 +78,85 @@ public class ExternalRecommenderTraitsEditor
         remoteUrl.setRequired(true);
         remoteUrl.add(new UrlValidator());
         form.add(remoteUrl);
+        
+        Button applyButton = new Button("check") {
+    		private static final long serialVersionUID = 1L;
 
+    		public void onSubmit() {
+    			remoteUrl.add(new ExternalConnectionChecker());
+    		}
+
+    	};
+    	
+    	form.add((IFormValidator) applyButton);
+        
+        add(new FeedbackPanel("feedbackMessage", 
+        		new ExactErrorLevelFilter(FeedbackMessage.ERROR)).setOutputMarkupId(true));
+        add(new FeedbackPanel("succesMessage", 
+        		new ExactErrorLevelFilter(FeedbackMessage.SUCCESS)).setOutputMarkupId(true));
+        
         CheckBox trainable = new CheckBox("trainable");
         form.add(trainable);
 
         add(form);
     }
+    
+    
+    
+    
+    class ExactErrorLevelFilter implements IFeedbackMessageFilter{
+    	private int errorLevel;
+
+		public ExactErrorLevelFilter(int errorLevel){
+			this.errorLevel = errorLevel;
+		}
+
+		@Override
+		public boolean accept(FeedbackMessage message) {
+			return message.getLevel() == errorLevel;
+		}
+    }
+
+    class ExternalConnectionChecker implements IValidator<String>  {
+
+		@Override
+		public void validate(IValidatable<String> validatable){
+			String urlRecieved = validatable.getValue();
+
+			HttpURLConnection.setFollowRedirects(false);
+		    HttpURLConnection con = null;
+			try {
+				con = (HttpURLConnection) new URL(urlRecieved).openConnection();
+			} catch (MalformedURLException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		    try {
+				con.setRequestMethod("HEAD");
+			} catch (ProtocolException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+		    try {
+				if(con.getResponseCode() != 200){
+					ValidationError error = new ValidationError(this);
+					error.setVariable("statusCode", 
+							+con.getResponseCode());
+					validatable.error(error);
+				}
+			} catch (IOException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+
+		}
+
+    }	
+    
+    
+    
 }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
@@ -16,3 +16,4 @@
 
 remoteUrl=Remote URL
 trainable=Trainable
+ExternalConnectionChecker=Error in connection establishment and returned with '${statusCode}'

--- a/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderConformityTest.java
+++ b/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderConformityTest.java
@@ -49,6 +49,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridRecommenderTraits;
 import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridRecommenderTraitsEditor;
 import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridService;
@@ -61,7 +62,7 @@ public class LappsGridRecommenderConformityTest
 {
     @Test
     @Parameters(method = "getNerServices")
-    public void testNerConformity(LappsGridService aService) throws Exception
+    public void testNerConformity(LappsGridService aService) throws Exception 
     {
         CAS cas = loadData();
 
@@ -80,7 +81,7 @@ public class LappsGridRecommenderConformityTest
 
     @Test
     @Parameters(method = "getPosServices")
-    public void testPosConformity(LappsGridService aService) throws Exception
+    public void testPosConformity(LappsGridService aService) throws Exception 
     {
         CAS cas = loadData();
 
@@ -97,7 +98,7 @@ public class LappsGridRecommenderConformityTest
         softly.assertAll();
     }
 
-    private void predict(String aUrl, CAS aCas) throws Exception
+    private void predict(String aUrl, CAS aCas) throws RecommendationException 
     {
         LappsGridRecommenderTraits traits = new LappsGridRecommenderTraits();
         traits.setUrl(aUrl);
@@ -141,8 +142,8 @@ public class LappsGridRecommenderConformityTest
         return services.get("pos");
     }
 
-    private static Map<String, List<LappsGridService>> loadPredefinedServicesData()
-            throws Exception
+    private static Map<String, List<LappsGridService>> loadPredefinedServicesData() throws IOException
+            
     {
         try (InputStream is = LappsGridRecommenderTraitsEditor
                 .class.getResourceAsStream("services.json")) {

--- a/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsRecommenderIntegrationTest.java
+++ b/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsRecommenderIntegrationTest.java
@@ -44,6 +44,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridRecommenderTraits;
 import okhttp3.mockwebserver.Dispatcher;
@@ -76,14 +77,14 @@ public class LappsRecommenderIntegrationTest
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown() throws IOException 
     {
         server.shutdown();
     }
 
     @Test
     @Ignore
-    public void thatPredictingPosWorks() throws Exception
+    public void thatPredictingPosWorks() throws IOException, UIMAException, RecommendationException 
     {
         RecommenderContext context = new RecommenderContext();
         CAS cas = loadData();

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
@@ -58,6 +58,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResu
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.PercentageBasedSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.RecommenderTestHelper;
 
@@ -82,7 +83,7 @@ public class OpenNlpDoccatRecommenderTest
     }
 
     @Test
-    public void thatTrainingWorks() throws Exception
+    public void thatTrainingWorks() throws IOException, UIMAException, RecommendationException 
     {
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
         List<CAS> casList = loadArxivData();
@@ -95,7 +96,7 @@ public class OpenNlpDoccatRecommenderTest
     }
 
     @Test
-    public void thatPredictionWorks() throws Exception
+    public void thatPredictionWorks() throws Exception 
     {
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
         List<CAS> casList = loadArxivData();
@@ -114,7 +115,7 @@ public class OpenNlpDoccatRecommenderTest
     }
 
     @Test
-    public void thatEvaluationWorks() throws Exception
+    public void thatEvaluationWorks() throws IOException, UIMAException, RecommendationException 
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
@@ -139,7 +140,7 @@ public class OpenNlpDoccatRecommenderTest
     }
 
     @Test
-    public void thatIncrementalNerEvaluationWorks() throws Exception
+    public void thatIncrementalNerEvaluationWorks() throws IOException, UIMAException, RecommendationException 
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 250, 10);
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
@@ -46,6 +46,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResu
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.PercentageBasedSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.RecommenderTestHelper;
 
@@ -70,7 +71,7 @@ public class OpenNlpPosRecommenderTest
     }
 
     @Test
-    public void thatTrainingWorks() throws Exception
+    public void thatTrainingWorks() throws IOException, UIMAException, RecommendationException 
     {
         OpenNlpPosRecommender sut = new OpenNlpPosRecommender(recommender, traits);
         List<CAS> casList = loadDevelopmentData();
@@ -83,7 +84,7 @@ public class OpenNlpPosRecommenderTest
     }
 
     @Test
-    public void thatPredictionWorks() throws Exception
+    public void thatPredictionWorks() throws Exception 
     {
         OpenNlpPosRecommender sut = new OpenNlpPosRecommender(recommender, traits);
         List<CAS> casList = loadDevelopmentData();
@@ -127,7 +128,7 @@ public class OpenNlpPosRecommenderTest
     }
 
     @Test
-    public void thatIncrementalPosEvaluationWorks() throws Exception
+    public void thatIncrementalPosEvaluationWorks() throws IOException, UIMAException, RecommendationException
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 250, 10);
         OpenNlpPosRecommender sut = new OpenNlpPosRecommender(recommender, traits);

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTest.java
@@ -56,6 +56,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResu
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.PercentageBasedSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.GazeteerEntry;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.RecommenderTestHelper;
@@ -135,7 +136,7 @@ public class StringMatchingRecommenderTest
                 .containsOnlyNulls();
     }
 
-    private CAS getTestCasNoLabelLabels() throws Exception
+    private CAS getTestCasNoLabelLabels() throws IOException, UIMAException
     {
         Dataset ds = loader.load("germeval2014-de", CONTINUE);
         CAS cas = loadData(ds, ds.getDataFiles()[0]).get(0);
@@ -148,7 +149,7 @@ public class StringMatchingRecommenderTest
     }
 
     @Test
-    public void thatPredictionWithPretrainigWorks() throws Exception
+    public void thatPredictionWithPretrainigWorks() throws Exception 
     {
         StringMatchingRecommender sut = new StringMatchingRecommender(recommender, traits);
         List<CAS> casList = loadDevelopmentData();
@@ -267,7 +268,7 @@ public class StringMatchingRecommenderTest
     }
     
     @Test
-    public void thatEvaluationSkippingWorks() throws Exception
+    public void thatEvaluationSkippingWorks() 
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
         StringMatchingRecommender sut = new StringMatchingRecommender(recommender, traits);

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporterTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporterTest.java
@@ -153,7 +153,7 @@ public class GazeteerExporterTest
                 .containsExactlyInAnyOrderElementsOf(gazeteers());
     }
 
-    private List<Gazeteer> gazeteers() throws Exception
+    private List<Gazeteer> gazeteers() 
     {
         Gazeteer gaz1 = new Gazeteer("gaz1", sourceRecommender);
         gaz1.setId(1l);

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.contentOf;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -111,13 +112,13 @@ public class GazeteerServiceImplTest
     }
     
     @After
-    public void tearDown() throws Exception
+    public void tearDown() 
     {
         testEntityManager.clear();
     }
 
     @Test
-    public void thatCreateListAndDeleteGazeteerWorks() throws Exception
+    public void thatCreateListAndDeleteGazeteerWorks() throws IOException 
     {
         // Add first gazeteer
         Gazeteer gaz1 = new Gazeteer("gaz1", rec1);
@@ -156,7 +157,7 @@ public class GazeteerServiceImplTest
     }
     
     @Test
-    public void thatUpdatingGazeteerWorks() throws Exception
+    public void thatUpdatingGazeteerWorks() 
     {
         Gazeteer gaz = new Gazeteer("foo", rec1);
         sut.createOrUpdateGazeteer(gaz);
@@ -176,7 +177,7 @@ public class GazeteerServiceImplTest
     }
     
     @Test
-    public void thatImportGazeteerWorks() throws Exception
+    public void thatImportGazeteerWorks() throws FileNotFoundException, IOException 
     {
         Gazeteer gaz = new Gazeteer("gaz", rec1);
         sut.createOrUpdateGazeteer(gaz);
@@ -212,7 +213,7 @@ public class GazeteerServiceImplTest
     }
     
     @Test
-    public void thatGazeteerCommentLineIsIgnored() throws Exception
+    public void thatGazeteerCommentLineIsIgnored() throws IOException 
     {
         Gazeteer gaz = new Gazeteer("gaz", rec1);
         
@@ -228,7 +229,7 @@ public class GazeteerServiceImplTest
     }
 
     @Test
-    public void thatInvalidGazeteerGeneratesException() throws Exception
+    public void thatInvalidGazeteerGeneratesException() 
     {
         Gazeteer gaz = new Gazeteer("gaz", rec1);
         

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -491,7 +491,7 @@ public interface KnowledgeBaseService
     /**
      * Can be used to re-index a local KB in case the full text index is corrupt.
      */
-    void rebuildFullTextIndex(KnowledgeBase aKb) throws Exception;
+    void rebuildFullTextIndex(KnowledgeBase aKb) ;
     
     /**
      * Read the concept with the given identifier from the given knowledge base with a 

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
@@ -211,7 +211,7 @@ public class KnowledgeBaseExporterTest
         return asList(feat1);
     }
 
-    private KnowledgeBase buildKnowledgeBase(String name) throws Exception
+    private KnowledgeBase buildKnowledgeBase(String name)
     {
         KnowledgeBase kb = new KnowledgeBase();
         kb.setRepositoryId("id-" + name);

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -141,7 +141,7 @@ public class KnowledgeBaseServiceRemoteTest
         sut.destroy();
     }
 
-    public KnowledgeBaseServiceRemoteTest(TestConfiguration aConfig) throws Exception
+    public KnowledgeBaseServiceRemoteTest(TestConfiguration aConfig) 
     {
         sutConfig = aConfig;
         

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -67,7 +67,7 @@ public class SPARQLQueryBuilderGenericTest
     private static final List<String> SKIPPED_PROFILES = asList("babel_net", "yago");
     
     @Parameterized.Parameters(name = "KB = {0}")
-    public static List<Object[]> data() throws Exception
+    public static List<Object[]> data() throws IOException 
     {
         Map<String, KnowledgeBaseProfile> profiles = KnowledgeBaseProfile.readKnowledgeBaseProfiles();
         
@@ -88,14 +88,14 @@ public class SPARQLQueryBuilderGenericTest
     private KnowledgeBase kb;
     private Repository repo;
     
-    public SPARQLQueryBuilderGenericTest(String aProfileName, KnowledgeBaseProfile aProfile) throws Exception
+    public SPARQLQueryBuilderGenericTest(String aProfileName, KnowledgeBaseProfile aProfile) 
     {
         profileName = aProfileName;
         profile = aProfile;
     }
     
     @Before
-    public void setup() throws Exception
+    public void setup() throws IOException 
     {
         // Force POST request instead of GET request
         // System.setProperty(SPARQLProtocolSession.MAXIMUM_URL_LENGTH_PARAM, "100");

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -253,9 +253,10 @@ public class SPARQLQueryBuilderTest
      * Checks that {@code SPARQLQueryBuilder#exists(RepositoryConnection, boolean)} can return 
      * {@code true} by querying for a list of all classes in {@link #DATA_CLASS_RDFS_HIERARCHY}
      * which contains a number of classes.
+     * @throws IOException 
      */
     @Test
-    public void thatExistsReturnsTrueWhenDataQueriedForExists() throws Exception
+    public void thatExistsReturnsTrueWhenDataQueriedForExists() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -268,9 +269,10 @@ public class SPARQLQueryBuilderTest
     /**
      * If the KB has no default language set, then only labels and descriptions with no language
      * at all should be returned.
+     * @throws IOException 
      */
     @Test
-    public void thatOnlyLabelsAndDescriptionsWithNoLanguageAreRetrieved() throws Exception
+    public void thatOnlyLabelsAndDescriptionsWithNoLanguageAreRetrieved() throws IOException 
     {
         kb.setDefaultLanguage(null);
         
@@ -326,9 +328,10 @@ public class SPARQLQueryBuilderTest
      * Checks that {@code SPARQLQueryBuilder#exists(RepositoryConnection, boolean)} can return 
      * {@code false} by querying for the parent of a root class in 
      * {@link #DATA_CLASS_RDFS_HIERARCHY} which does not exist.
+     * @throws IOException 
      */
     @Test
-    public void thatExistsReturnsFalseWhenDataQueriedForDoesNotExist() throws Exception
+    public void thatExistsReturnsFalseWhenDataQueriedForDoesNotExist() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -341,9 +344,10 @@ public class SPARQLQueryBuilderTest
     
     /**
      * Checks that an explicitly defined class can be retrieved using its identifier.
+     * @throws IOException 
      */
     @Test
-    public void thatExplicitClassCanBeRetrievedByItsIdentifier() throws Exception
+    public void thatExplicitClassCanBeRetrievedByItsIdentifier() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -372,9 +376,10 @@ public class SPARQLQueryBuilderTest
     /**
      * Checks that a either explicitly nor implicitly defined class can be retrieved using its 
      * identifier.
+     * @throws IOException 
      */
     @Test
-    public void thatNonClassCannotBeRetrievedByItsIdentifier() throws Exception
+    public void thatNonClassCannotBeRetrievedByItsIdentifier() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -387,9 +392,10 @@ public class SPARQLQueryBuilderTest
 
     /**
      * Checks that item information can be obtained for a given subject.
+     * @throws IOException 
      */
     @Test
-    public void thatCanRetrieveItemInfoForIdentifier() throws Exception
+    public void thatCanRetrieveItemInfoForIdentifier() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX,
                 DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
@@ -410,7 +416,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void thatAllPropertiesCanBeRetrieved() throws Exception
+    public void thatAllPropertiesCanBeRetrieved() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_PROPERTIES);
         
@@ -440,8 +446,8 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatPropertyQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults()
-        throws Exception
+    public void thatPropertyQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws IOException
+        
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_PROPERTIES);
         
@@ -496,7 +502,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatQueryLimitedToRootClassesDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatQueryLimitedToRootClassesDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -511,7 +517,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void thatQueryWithExplicitRootClassDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatQueryWithExplicitRootClassDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -529,7 +535,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void thatNonRootClassCanBeUsedAsExplicitRootClass() throws Exception
+    public void thatNonRootClassCanBeUsedAsExplicitRootClass() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -548,7 +554,7 @@ public class SPARQLQueryBuilderTest
                 .containsExactlyInAnyOrder("implicitRoot", "subclass2");
     }
     @Test
-    public void thatQueryLimitedToClassesDoesNotReturnInstances() throws Exception
+    public void thatQueryLimitedToClassesDoesNotReturnInstances() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -561,7 +567,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatQueryLimitedToInstancesDoesNotReturnClasses() throws Exception
+    public void thatQueryLimitedToInstancesDoesNotReturnClasses() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -574,7 +580,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void thatClassQueryLimitedToAnchestorsDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatClassQueryLimitedToAnchestorsDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
     
@@ -590,7 +596,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void thatClassQueryLimitedToParentsDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatClassQueryLimitedToParentsDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
     
@@ -605,7 +611,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatClassQueryLimitedToChildrenDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatClassQueryLimitedToChildrenDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
     
@@ -649,7 +655,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatClassQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatClassQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
     
@@ -744,7 +750,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void thatItemQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws Exception
+    public void thatItemQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
@@ -760,7 +766,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelContainingAnyOf_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelContainingAnyOf_RDF4J_withLanguage_noFTS() throws IOException 
     {
         kb.setFullTextSearchIri(null);
         
@@ -768,15 +774,15 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelContainingAnyOf_RDF4J_withLanguage_FTS() throws Exception
+    public void testWithLabelContainingAnyOf_RDF4J_withLanguage_FTS() throws IOException 
     {
         kb.setFullTextSearchIri(IriConstants.FTS_LUCENE);
         
         __testWithLabelContainingAnyOf_withLanguage(rdf4jLocalRepo);
     }
     
-    public void __testWithLabelContainingAnyOf_withLanguage(Repository aRepository)
-        throws Exception
+    public void __testWithLabelContainingAnyOf_withLanguage(Repository aRepository) throws IOException
+        
     {
         importDataFromString(TURTLE, TURTLE_PREFIX, DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
 
@@ -873,7 +879,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelMatchingExactlyAnyOf_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelMatchingExactlyAnyOf_RDF4J_withLanguage_noFTS() throws IOException 
     {
         kb.setFullTextSearchIri(null);
         
@@ -881,15 +887,15 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelMatchingExactlyAnyOf_RDF4J_withLanguage_FTS() throws Exception
+    public void testWithLabelMatchingExactlyAnyOf_RDF4J_withLanguage_FTS() throws IOException 
     {
         kb.setFullTextSearchIri(IriConstants.FTS_LUCENE);
         
         __testWithLabelMatchingExactlyAnyOf_withLanguage(rdf4jLocalRepo);
     }
 
-    public void __testWithLabelMatchingExactlyAnyOf_withLanguage(Repository aRepository)
-        throws Exception
+    public void __testWithLabelMatchingExactlyAnyOf_withLanguage(Repository aRepository) throws IOException
+        
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX,
                 DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
@@ -910,7 +916,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty_noFTS() throws Exception
+    public void testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty_noFTS() throws IOException 
     {
         kb.setFullTextSearchIri(null);
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF);
@@ -920,7 +926,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty_FTS() throws Exception
+    public void testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty_FTS() throws IOException 
     {
         kb.setFullTextSearchIri(IriConstants.FTS_LUCENE);
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF);
@@ -929,8 +935,8 @@ public class SPARQLQueryBuilderTest
         __testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty(rdf4jLocalRepo);
     }
     
-    public void __testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty(Repository aRepository)
-        throws Exception
+    public void __testWithLabelMatchingExactlyAnyOf_RDF4J_subproperty(Repository aRepository) throws IOException
+        
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, LABEL_SUBPROPERTY);
         
@@ -965,7 +971,7 @@ public class SPARQLQueryBuilderTest
         __testWithLabelStartingWith_RDF4J_withoutLanguage();
     }
 
-    public void __testWithLabelStartingWith_RDF4J_withoutLanguage() throws Exception
+    public void __testWithLabelStartingWith_RDF4J_withoutLanguage() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_LABELS_WITHOUT_LANGUAGE);
     
@@ -984,7 +990,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
 
@@ -1006,7 +1012,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_1() throws Exception
+    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_1() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
 
@@ -1030,7 +1036,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_2() throws Exception
+    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_2() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
 
@@ -1054,7 +1060,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_3() throws Exception
+    public void testWithLabelStartingWith_RDF4J_withLanguage_FTS_3() throws IOException 
     {
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX,
                 DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
@@ -1072,7 +1078,7 @@ public class SPARQLQueryBuilderTest
     }
     
     @Test
-    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_1() throws Exception
+    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_1() 
     {
         assertIsReachable(ukpVirtuosoRepo);
         
@@ -1092,7 +1098,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_2() throws Exception
+    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_2() 
     {
         assertIsReachable(ukpVirtuosoRepo);
         
@@ -1113,7 +1119,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_3() throws Exception
+    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_3() 
     {
         assertIsReachable(ukpVirtuosoRepo);
         
@@ -1134,7 +1140,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_4() throws Exception
+    public void testWithLabelStartingWith_Virtuoso_withLanguage_FTS_4() 
     {
         assertIsReachable(ukpVirtuosoRepo);
         
@@ -1233,7 +1239,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelMatchingExactlyAnyOf_Wikidata_noFTS() throws Exception
+    public void testWithLabelMatchingExactlyAnyOf_Wikidata_noFTS() 
     {
         assertIsReachable(wikidata);
         
@@ -1308,7 +1314,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_HUCIT_noFTS() throws Exception
+    public void testWithLabelStartingWith_HUCIT_noFTS() 
     {
         assertIsReachable(hucit);
         
@@ -1326,7 +1332,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelStartingWith_onlyDescendants_HUCIT_noFTS() throws Exception
+    public void testWithLabelStartingWith_onlyDescendants_HUCIT_noFTS() 
     {
         assertIsReachable(hucit);
         
@@ -1473,7 +1479,7 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
-    public void testWithLabelContainingAnyOf_RDF4J_pets_ttl() throws Exception
+    public void testWithLabelContainingAnyOf_RDF4J_pets_ttl() throws IOException 
     {
         importDataFromFile("src/test/resources/data/pets.ttl");
 

--- a/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
+++ b/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
@@ -64,7 +64,7 @@ public class EventRepositoryImplIntegrationTest  {
     private LoggedEvent le;
 
     @Before
-    public void setUp() throws Exception
+    public void setUp()
     {
         sut = new EventRepositoryImpl(testEntityManager.getEntityManager());
         project = createProject(PROJECT_NAME);
@@ -72,7 +72,7 @@ public class EventRepositoryImplIntegrationTest  {
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown()
     {
         testEntityManager.clear();
     }

--- a/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/exporter/LoggedEventExporterTest.java
+++ b/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/exporter/LoggedEventExporterTest.java
@@ -29,6 +29,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
@@ -66,7 +67,7 @@ public class LoggedEventExporterTest
     private LoggedEventExporter sut;
 
     @Before
-    public void setUp() throws Exception
+    public void setUp() throws IOException
     {
         initMocks(this);
 
@@ -181,8 +182,8 @@ public class LoggedEventExporterTest
         return asList(event1, event2, event3, event4);
     }
 
-    private ArgumentCaptor<LoggedEvent> runExportImportAndFetchEvents(ZipFile aZipFile)
-        throws Exception
+    private ArgumentCaptor<LoggedEvent> runExportImportAndFetchEvents(ZipFile aZipFile) throws Exception
+        
     {
         // Export the project
         ProjectExportRequest exportRequest = new ProjectExportRequest();

--- a/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoModelTest.java
+++ b/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoModelTest.java
@@ -45,7 +45,7 @@ public class PdfAnnoModelTest
     }
 
     @Test
-    public void testgetAnnoFileContent() throws Exception
+    public void testgetAnnoFileContent() 
     {
         String annoFileString = pdfAnnoModel.getAnnoFileContent();
         assertThat(linesOf(new File("src/test/resources/annoFile.anno"),

--- a/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
+++ b/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
@@ -29,15 +29,20 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Scanner;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.collection.CollectionException;
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.fit.factory.CollectionReaderFactory;
 import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.resource.ResourceInitializationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -150,9 +155,13 @@ public class PdfAnnoRendererTest
 
     /**
      * Tests if anno file is correctly rendered for a given document
+     * @throws CASException 
+     * @throws ResourceInitializationException 
+     * @throws IOException 
+     * @throws CollectionException 
      */
     @Test
-    public void testRender() throws Exception
+    public void testRender() throws ResourceInitializationException, CASException, CollectionException, IOException 
     {
         String file = "src/test/resources/tcf04-karin-wl.xml";
         String pdftxt = new Scanner(

--- a/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfExtractFileTest.java
+++ b/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfExtractFileTest.java
@@ -21,10 +21,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.file.Paths;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import de.tudarmstadt.ukp.inception.pdfeditor.PdfAnnotationEditor;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.Offset;
@@ -35,7 +39,7 @@ public class PdfExtractFileTest
     private PdfExtractFile pdfExtractFile;
 
     @Before
-    public void setup() throws Exception
+    public void setup() throws IOException, ParserConfigurationException, SAXException 
     {
         String pdftxt = new String(readAllBytes(Paths.get("src/test/resources/pdfextract.txt")),
                 UTF_8);

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -91,7 +91,7 @@ public class RecommendationServiceImplIntegrationTest
     private AnnotationFeature feature;
 
     @Before
-    public void setUp() throws Exception
+    public void setUp() 
     {
         sut = new RecommendationServiceImpl(sessionRegistry, userRepository,
                 recommenderFactoryRegistry, schedulingService, annoService, documentService,
@@ -108,7 +108,7 @@ public class RecommendationServiceImplIntegrationTest
     }
 
     @After
-    public void tearDown() throws Exception
+    public void tearDown() 
     {
         testEntityManager.clear();
     }

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
@@ -29,8 +29,10 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -71,7 +73,7 @@ public class VisibilityCalculationTests
     private final static String COVERED_TEXT = "TestText";
 
     @Before
-    public void setUp() throws Exception
+    public void setUp()
     {
         initMocks(this);
 
@@ -189,7 +191,7 @@ public class VisibilityCalculationTests
         return SuggestionGroup.group(suggestions);
     }
 
-    private CAS getTestCas() throws Exception
+    private CAS getTestCas() throws ResourceInitializationException, CASException
     {
         String documentText = "Dies ist ein Testtext, ach ist der schoen, der schoenste von allen"
                 + " Testtexten.";


### PR DESCRIPTION
**What's in the PR**
* Removed generic exceptions and replaced them with dedicated exceptions because Dedicated exceptions are better compared to generic exceptions because the dedicated exceptions clearly explains about the exception caused in the application.
