### PR TITLE
Bugfix/#3 @deprecated code should be removed

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -1177,7 +1177,7 @@ public class ActiveLearningSidebar
         ) {
             AnnotationSuggestion suggestion = alState.getSuggestion().get();
             if (
-                    acceptedSuggestion.getOffset().equals(suggestion.getOffset()) && 
+                (new Offset(acceptedSuggestion.getBegin(),acceptedSuggestion.getEnd())).equals(new Offset(acceptedSuggestion.getBegin(),acceptedSuggestion.getEnd())) &&
                     vid.getLayerId() == suggestion.getLayerId() && 
                     acceptedSuggestion.getFeature().equals(suggestion.getFeature())
             ) {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -251,7 +251,7 @@ public class ExportedKnowledgeBase
         reification = aReification;
     }
 
-    @Deprecated
+   /* @Deprecated
     public void setSupportConceptLinking(boolean aSupportConceptLinking) {
         supportConceptLinking = aSupportConceptLinking;
     }
@@ -259,7 +259,7 @@ public class ExportedKnowledgeBase
     @Deprecated
     public boolean isSupportConceptLinking() {
         return supportConceptLinking;
-    }
+    }*/
 
     public String getBasePrefix()
     {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -118,7 +118,7 @@ public class KnowledgeBaseExporter implements ProjectExporter
             exportedKB.setReadOnly(kb.isReadOnly());
             exportedKB.setEnabled(kb.isEnabled());
             exportedKB.setReification(kb.getReification().toString());
-            exportedKB.setSupportConceptLinking(kb.isSupportConceptLinking());
+            //exportedKB.setSupportConceptLinking(kb.isSupportConceptLinking()); // Removed setSupportConceptLinking as it is deprecated function in ExportedKnowledgeBase.java
             exportedKB.setBasePrefix(kb.getBasePrefix());
             exportedKB.setRootConcepts(
                 kb.getRootConcepts()
@@ -213,7 +213,7 @@ public class KnowledgeBaseExporter implements ProjectExporter
             // The imported project may date from a time where we did not yet have the FTS IRI.
             // In that case we use concept linking support as an indicator that we dealt with a
             // remote Virtuoso.
-            if (exportedKB.isSupportConceptLinking() && exportedKB.getFullTextSearchIri() == null) {
+            if (exportedKB.getFullTextSearchIri() == null) {
                 kb.setFullTextSearchIri(IriConstants.FTS_VIRTUOSO);
             }
             kb.setFullTextSearchIri(exportedKB.getFullTextSearchIri() != null

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -42,11 +42,11 @@ public class KBHandle
     private String debugInfo;
     
     // domain and range for cases in which the KBHandle represents a property
-    @Deprecated
-    private String domain;
+   // @Deprecated
+    //private String domain;
     
-    @Deprecated
-    private String range;
+    //@Deprecated
+   // private String range;
 
     public KBHandle()
     {
@@ -78,6 +78,7 @@ public class KBHandle
         language = aLanguage;
     }
 
+    /*
     @Deprecated
     public KBHandle(String aIdentifier, String aLabel, String aDescription, String aLanguage,
             String aDomain, String aRange)
@@ -90,6 +91,10 @@ public class KBHandle
         range = aRange;
     }
 
+     */
+
+
+    /*
     @Deprecated
     public String getDomain()
     {
@@ -113,6 +118,8 @@ public class KBHandle
     {
         range = aRange;
     }
+
+     */
 
     public String getDescription()
     {
@@ -214,8 +221,8 @@ public class KBHandle
             property.setLanguage(aHandle.getLanguage());
             property.setDescription(aHandle.getDescription());
             property.setName(aHandle.getName());
-            property.setRange(aHandle.getRange());
-            property.setDomain(aHandle.getDomain());
+        //    property.setRange(aHandle.getRange());  Depricated functions. There isn't a function to call these variables.
+        //    property.setDomain(aHandle.getDomain());
             return (T) property;
         }
         else if (aClass == KBHandle.class) {
@@ -267,12 +274,13 @@ public class KBHandle
         if (language != null) {
             builder.append("language", language);
         }
+        /*
         if (domain != null) {
             builder.append("domain", domain);
         }
         if (range != null) {
             builder.append("range", range);
-        }
+        }*/
         return builder.toString();
     }
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1749,7 +1749,7 @@ public class SPARQLQueryBuilder
     {
         Binding domain = aSourceBindings.getBinding(VAR_DOMAIN_NAME);
         if (domain != null) {
-            aTargetHandle.setDomain(domain.getValue().stringValue());
+            //aTargetHandle.setDomain(domain.getValue().stringValue());
         }
     }
 
@@ -1757,7 +1757,7 @@ public class SPARQLQueryBuilder
     {
         Binding range = aSourceBindings.getBinding(VAR_RANGE_NAME);
         if (range != null) {
-            aTargetHandle.setRange(range.getValue().stringValue());
+            //aTargetHandle.setRange(range.getValue().stringValue());
         }
     }
     

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -425,12 +425,16 @@ public class SPARQLQueryBuilderTest
                 .usingElementComparatorOnFields(
                         "identifier", "name", "description", "range", "domain")
                 .containsExactlyInAnyOrder(
-                        new KBHandle("http://example.org/#property-1", "Property 1",
-                                "Property One", null, "http://example.org/#explicitRoot", 
+                        /*new KBHandle("http://example.org/#property-1", "Property 1",
+                                "Property One", null, "http://example.org/#explicitRoot",
                                 "http://www.w3.org/2001/XMLSchema#string"),
                         new KBHandle("http://example.org/#property-2", "Property 2",
-                                "Property Two", null, "http://example.org/#subclass1", 
-                                "http://www.w3.org/2001/XMLSchema#Integer"),
+                                "Property Two", null, "http://example.org/#subclass1",
+                                "http://www.w3.org/2001/XMLSchema#Integer"),*/
+                    new KBHandle("http://example.org/#property-1", "Property 1",
+                        "Property One", null),
+                    new KBHandle("http://example.org/#property-2", "Property 2",
+                        "Property Two", null),
                         new KBHandle("http://example.org/#property-3", "Property 3",
                                 "Property Three"),
                         new KBHandle("http://example.org/#subproperty-1-1", "Subproperty 1-1",

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
@@ -48,8 +48,8 @@ public class ExtendedId
         this.annotationId = annotationId;
         this.sentenceId = sentenceId;
         this.recommenderId = recommenderId;
-        this.begin = offset.getBeginCharacter();
-        this.end = offset.getEndCharacter();
+        this.begin = offset.getBegin();
+        this.end = offset.getEnd();
     }
 
     public String getDocumentName()

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
@@ -127,6 +127,8 @@ public class LearningRecord
         this.offsetTokenEnd = offsetTokenEnd;
     }
 
+   // public int[] setTokenEnds(int)
+
     public int getOffsetCharacterBegin() {
         return offsetCharacterBegin;
     }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
@@ -64,7 +64,7 @@ public class Offset
     }
     
     @Deprecated
-    public int Start()
+    public int getStart()
     {
         return getBegin();
     }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
@@ -64,7 +64,7 @@ public class Offset
     }
     
     @Deprecated
-    public int getStart()
+    public int Start()
     {
         return getBegin();
     }
@@ -101,9 +101,9 @@ public class Offset
         //  4        |        #######         |
         //           |                        |
 
-        return (((i.getStart() <= getStart()) && (getStart() < i.getEnd())) || // Case 1-3
-                ((i.getStart() < getEnd()) && (getEnd() <= i.getEnd())) || // Case 1-3
-                ((getStart() <= i.getStart()) && (i.getEnd() <= getEnd()))); // Case 4
+        return (((i.getBegin() <= getBegin()) && (getBegin() < i.getEnd())) || // Case 1-3
+                ((i.getBegin() < getEnd()) && (getEnd() <= i.getEnd())) || // Case 1-3
+                ((getBegin() <= i.getBegin()) && (i.getEnd() <= getEnd()))); // Case 4
     }    
     @Override
     public int hashCode()

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -213,8 +213,8 @@ public class Predictions
         return predictions.entrySet().stream()
             .filter(f -> f.getKey().getDocumentName().equals(aDocumentName))
             .filter(f -> f.getKey().getLayerId() == aLayer.getId())
-            .filter(f -> f.getKey().getOffset().getBeginCharacter() == aBegin)
-            .filter(f -> f.getKey().getOffset().getEndCharacter() == aEnd)
+            .filter(f -> f.getKey().getOffset().getBegin() == aBegin)
+            .filter(f -> f.getKey().getOffset().getEnd() == aEnd)
             .filter(f -> f.getValue().getFeature().equals(aFeature))
             .map(Map.Entry::getValue)
             .collect(Collectors.toList());

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -164,7 +164,7 @@ public class Predictions
     {
         aPredictions.forEach(prediction -> {
             predictions.put(new ExtendedId(user.getUsername(), project.getId(),
-                    prediction.getDocumentName(), aLayerId, prediction.getOffset(),
+                    prediction.getDocumentName(), aLayerId, new Offset(prediction.getBegin(), prediction.getEnd()),
                     prediction.getRecommenderId(), prediction.getId(), -1), prediction);
 
         });
@@ -213,8 +213,8 @@ public class Predictions
         return predictions.entrySet().stream()
             .filter(f -> f.getKey().getDocumentName().equals(aDocumentName))
             .filter(f -> f.getKey().getLayerId() == aLayer.getId())
-            .filter(f -> f.getKey().getOffset().getBegin() == aBegin)
-            .filter(f -> f.getKey().getOffset().getEnd() == aEnd)
+            .filter(f -> new Offset(f.getKey().getBegin(), f.getKey().getEnd()).getBegin() == aBegin)
+            .filter(f -> new Offset(f.getKey().getBegin(), f.getKey().getEnd()).getEnd() == aEnd)
             .filter(f -> f.getValue().getFeature().equals(aFeature))
             .map(Map.Entry::getValue)
             .collect(Collectors.toList());

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
@@ -81,7 +81,7 @@ public class SuggestionGroup
         suggestions = new ArrayList<>(asList(aItems));
         sorted = suggestions.size() < 2;
         if (!suggestions.isEmpty()) {
-            offset = suggestions.get(0).getOffset();
+            offset = new Offset(suggestions.get(0).getBegin(), suggestions.get(0).getEnd());
             feature = get(0).getFeature();
             layerId = get(0).getLayerId();
             documentName = get(0).getDocumentName();
@@ -265,7 +265,7 @@ public class SuggestionGroup
         
         // Cache information that must be consistent in the group when the first item is added
         if (empty) {
-            offset = aSuggestion.getOffset();
+            offset = new Offset(aSuggestion.getBegin(), aSuggestion.getEnd());
             feature = aSuggestion.getFeature();
             layerId = aSuggestion.getLayerId();
             documentName = aSuggestion.getDocumentName();

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
@@ -100,8 +100,8 @@ public class LearningRecordServiceImpl
         record.setUserAction(aUserAction);
         record.setOffsetCharacterBegin(aSuggestion.getBegin());
         record.setOffsetCharacterEnd(aSuggestion.getEnd());
-        record.setOffsetTokenBegin(-1);
-        record.setOffsetTokenEnd(-1);
+        //record.setOffsetTokenBegin(-1);
+        //record.setOffsetTokenEnd(-1);
         record.setTokenText(aSuggestion.getCoveredText());
         record.setAnnotation(aAlternativeLabel);
         record.setLayer(aLayer);
@@ -124,8 +124,8 @@ public class LearningRecordServiceImpl
                 "ORDER BY l.id desc");
         TypedQuery<LearningRecord> query = entityManager.createQuery(sql, LearningRecord.class)
                 .setParameter("user", aUsername)
-                .setParameter("layer", aLayer)
-                .setParameter("action", LearningRecordType.SHOWN); // SHOWN records NOT returned
+                .setParameter("layer", aLayer);
+               // .setParameter("action", LearningRecordType.SHOWN) // SHOWN records NOT returned
         if (aLimit > 0) {
             query = query.setMaxResults(aLimit);
         }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
@@ -220,7 +220,7 @@ public class OverlapIterator
         // Seek back to the first segment that does not overlap
         // with curb and at most until the last b step we made.
         boolean steppedBack = false;
-        while ((_na > _last_b_step_na) && (_cura.getEnd() > _curb.getBegin())) {
+        while ((_na > _last_b_step_na) && (_cura.getEndCharacter() > _curb.getBeginCharacter())) {
             stepBackA();
             steppedBack = true;
         }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
@@ -220,7 +220,7 @@ public class OverlapIterator
         // Seek back to the first segment that does not overlap
         // with curb and at most until the last b step we made.
         boolean steppedBack = false;
-        while ((_na > _last_b_step_na) && (_cura.getEndCharacter() > _curb.getBeginCharacter())) {
+        while ((_na > _last_b_step_na) && (_cura.getEnd() > _curb.getBegin())) {
             stepBackA();
             steppedBack = true;
         }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
@@ -200,7 +200,7 @@ public class OverlapIterator
             _log.trace("   -> B: " + _nb + "/" + _maxb + " " + _curb);
         }
 
-        if (_curb.getBeginCharacter() < _cura.getEndCharacter()) {
+        if (_curb.getBegin() < _cura.getEnd()) {
             // Rewind A to the point where it was when we last stepped
             // up B.
             rewindA();

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
@@ -121,9 +121,9 @@ public class OverlapIterator
         }
 
         final boolean nexta_starts_before_curb_ends = (nexta != null)
-                && (nexta.getBeginCharacter() <= _curb.getEndCharacter());
-        final boolean cura_ends_before_or_with_curb = _cura.getEndCharacter() <= _curb
-                .getEndCharacter();
+                && (nexta.getBegin() <= _curb.getEnd());
+        final boolean cura_ends_before_or_with_curb = _cura.getEnd() <= _curb
+                .getEnd();
 
         if (_log.isTraceEnabled()) {
             _log.trace("---");

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
@@ -80,7 +80,7 @@ public class VisibilityCalculationTests
 
         layer = new AnnotationLayer();
         layer.setName(neName);
-        layer.setId(new Long(42));
+        layer.setId(Long.valueOf(42));
         layerId = layer.getId();
 
         project = new Project();


### PR DESCRIPTION
The deprecated course has been modified.

**What's in the PR**
We modified each instance differently such as 'getBeginCharacter', 'getEndCharacter' into 'getBegin', 'getEnd' because the function finally calls these functions eventually.
As 'domain' and 'range' where deprecated, we removed the constructor with parameters 'domain' and 'range'. We also commented out the 'getDomain' and 'getRange 'functions as their parameters were deprecated as well. One of the  KBHandle is also removed because of the 'getDomain' and 'getRange', we can call the instances having 2 to 4 augments in this class but if we want to call a funtion with 6 augments it is not possible.
As the 'getOffset' function is deprecated we removed it and created a new object instance in every place instead. we created two augments(getBegin, getEnd) and instead of the return in 'getOffset' function.
**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
