### PR TITLE
[M19]:Rename "feature" which hides the field declared at line.

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
@@ -156,7 +156,7 @@ public class StringMatchingRecommenderTraitsEditor
     {
         private static final long serialVersionUID = -2049981253344229438L;
         
-        private ListView<Gazeteer> gazeteerList;
+        private ListView<Gazeteer> privgazeteerList;
         
         public GazeteerList(String aId, IModel<? extends List<Gazeteer>> aChoices)
         {
@@ -164,7 +164,7 @@ public class StringMatchingRecommenderTraitsEditor
             
             setOutputMarkupPlaceholderTag(true);
             
-            gazeteerList = new ListView<Gazeteer>("gazeteer", aChoices) {
+            privgazeteerList = new ListView<Gazeteer>("gazeteer", aChoices) {
                 private static final long serialVersionUID = 2827701590781214260L;
 
                 @Override
@@ -182,7 +182,7 @@ public class StringMatchingRecommenderTraitsEditor
                             gazeteer.getName()));
                 }
             };
-            add(gazeteerList);
+            add(privgazeteerList);
         }
         
         private File getGazeteerFile(Gazeteer aGazeteer)

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -171,9 +171,9 @@ public class KnowledgeBaseServiceImplIntegrationTest  {
 
     @Test
     public void getKnowledgeBases_WithoutKnowledgeBases_ShouldReturnEmptyList() {
-        Project project = createProject("Empty project");
+        Project updatedproject = createProject("Empty project");
 
-        List<KnowledgeBase> knowledgeBases = sut.getKnowledgeBases(project);
+        List<KnowledgeBase> knowledgeBases = sut.getKnowledgeBases(updatedproject);
 
         assertThat(knowledgeBases)
             .as("Check that no knowledge base is found")

--- a/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
+++ b/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
@@ -252,29 +252,29 @@ public class EventRepositoryImplIntegrationTest  {
     // Helper
     private Project createProject(String aName)
     {
-        Project project = new Project();
-        project.setName(aName);
-        project.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
-        return testEntityManager.persist(project);
+        Project updatedproject = new Project();
+        updatedproject.setName(aName);
+        updatedproject.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
+        return testEntityManager.persist(updatedproject);
     }
 
     private LoggedEvent buildLoggedEvent(Project aProject, String aUsername,
             String aEventType, Date aDate, long aDocId, String aDetails)
     {
-        LoggedEvent le = new LoggedEvent();
-        le.setUser(aUsername);
-        le.setProject(aProject.getId());
-        le.setDetails(aDetails);
-        le.setCreated(aDate);
-        le.setEvent(aEventType);
-        le.setDocument(aDocId);
-        return le;
+        LoggedEvent logev = new LoggedEvent();
+        logev.setUser(aUsername);
+        logev.setProject(aProject.getId());
+        logev.setDetails(aDetails);
+        logev.setCreated(aDate);
+        logev.setEvent(aEventType);
+        logev.setDocument(aDocId);
+        return logev;
     }
 
     public User createUser(String aUsername)
     {
-        User user = new User();
-        user.setUsername(aUsername);
-        return testEntityManager.persist(user);
+        User newuser = new User();
+        newuser.setUsername(aUsername);
+        return testEntityManager.persist(newuser);
     }
 }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/evaluation/ConfusionMatrix.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/evaluation/ConfusionMatrix.java
@@ -34,23 +34,23 @@ public class ConfusionMatrix implements Serializable
     /**
      * Stores number of predicted labels for each gold label
      */
-    private Object2IntOpenHashMap<ConfMatrixKey> confusionMatrix;
+    private Object2IntOpenHashMap<ConfMatrixKey> privconfusionMatrix;
     private Set<String> labels;
     private int total;
 
     public ConfusionMatrix()
     {
-        confusionMatrix = new Object2IntOpenHashMap<>();
+        privconfusionMatrix = new Object2IntOpenHashMap<>();
         labels = new LinkedHashSet<>();
     }
     
     
     public int getEntryCount(String aPredictedLabel, String aGoldLabel) {
-        return confusionMatrix.getInt(new ConfMatrixKey(aGoldLabel, aPredictedLabel));
+        return privconfusionMatrix.getInt(new ConfMatrixKey(aGoldLabel, aPredictedLabel));
     }
     
     public boolean containsEntry(String aPredictedLabel, String aGoldLabel) {
-        return confusionMatrix.containsKey(new ConfMatrixKey(aGoldLabel, aPredictedLabel));
+        return privconfusionMatrix.containsKey(new ConfMatrixKey(aGoldLabel, aPredictedLabel));
     }
     
     /**
@@ -66,12 +66,12 @@ public class ConfusionMatrix implements Serializable
 
         // annotated pair is true positive
         if (aGoldLabel.equals(aPredictedLabel)) {
-            confusionMatrix.addTo(new ConfMatrixKey(aGoldLabel, aGoldLabel), 1);
+            privconfusionMatrix.addTo(new ConfMatrixKey(aGoldLabel, aGoldLabel), 1);
         }
         else {
             // annotated pair is false negative for gold class = annotated pair is false
             // positive for predicted class
-            confusionMatrix.addTo(new ConfMatrixKey(aGoldLabel, aPredictedLabel), 1);
+            privconfusionMatrix.addTo(new ConfMatrixKey(aGoldLabel, aPredictedLabel), 1);
         }
     }
 
@@ -87,12 +87,12 @@ public class ConfusionMatrix implements Serializable
 
     public Object2IntOpenHashMap<ConfMatrixKey> getConfusionMatrix()
     {
-        return confusionMatrix;
+        return privconfusionMatrix;
     }
 
     public void addMatrix(ConfusionMatrix aMatrix) {
         for (Entry<ConfMatrixKey> entry : aMatrix.getConfusionMatrix().object2IntEntrySet()) {
-            confusionMatrix.addTo(entry.getKey(), entry.getIntValue());
+            privconfusionMatrix.addTo(entry.getKey(), entry.getIntValue());
         }
     }
 
@@ -113,7 +113,7 @@ public class ConfusionMatrix implements Serializable
             matrixStr.append("\t| ");
             for (String predictedLabel : labels) {
                 matrixStr.append(
-                        confusionMatrix.getInt(new ConfMatrixKey(goldLabel, predictedLabel)));
+                        privconfusionMatrix.getInt(new ConfMatrixKey(goldLabel, predictedLabel)));
                 matrixStr.append("\t| ");
             }
             matrixStr.append("\n");

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -49,7 +49,7 @@ public class Predictions
 {
     private static final long serialVersionUID = -1598768729246662885L;
     
-    private Map<ExtendedId, AnnotationSuggestion> predictions = new ConcurrentHashMap<>();
+    private Map<ExtendedId, AnnotationSuggestion> betterpredictions = new ConcurrentHashMap<>();
     
     private final Project project;
     private final User user;
@@ -67,7 +67,7 @@ public class Predictions
         user = aUser;
 
         if (aPredictions != null) {
-            predictions = new ConcurrentHashMap<ExtendedId, AnnotationSuggestion>(aPredictions);
+            betterpredictions = new ConcurrentHashMap<ExtendedId, AnnotationSuggestion>(aPredictions);
         }
     }
     
@@ -119,7 +119,7 @@ public class Predictions
     private List<AnnotationSuggestion> getFlattenedPredictions(String aDocumentName,
         AnnotationLayer aLayer, int aWindowBegin, int aWindowEnd)
     {
-        return predictions.entrySet().stream()
+        return betterpredictions.entrySet().stream()
             .filter(f -> f.getKey().getDocumentName().equals(aDocumentName))
             .filter(f -> f.getKey().getLayerId() == aLayer.getId())
             .filter(f -> aWindowBegin == -1 || (f.getKey().getBegin() >= aWindowBegin))
@@ -135,7 +135,7 @@ public class Predictions
      */
     public Optional<AnnotationSuggestion> getPredictionByVID(SourceDocument aDocument, VID aVID)
     {
-        return predictions.values().stream()
+        return betterpredictions.values().stream()
                 .filter(f -> f.getDocumentName().equals(aDocument.getName()))
                 .filter(f -> f.getId() == aVID.getSubId())
                 .filter(f -> f.getRecommenderId() == aVID.getId())
@@ -148,7 +148,7 @@ public class Predictions
     public Optional<AnnotationSuggestion> getPrediction(SourceDocument aDocument, int aBegin,
             int aEnd, String aLabel)
     {
-        return predictions.values().stream()
+        return betterpredictions.values().stream()
                 .filter(f -> f.getDocumentName().equals(aDocument.getName()))
                 .filter(f -> f.getBegin() == aBegin && f.getEnd() == aEnd)
                 .filter(f -> f.getLabel().equals(aLabel))
@@ -163,7 +163,7 @@ public class Predictions
     public void putPredictions(long aLayerId, List<AnnotationSuggestion> aPredictions)
     {
         aPredictions.forEach(prediction -> {
-            predictions.put(new ExtendedId(user.getUsername(), project.getId(),
+            betterpredictions.put(new ExtendedId(user.getUsername(), project.getId(),
                     prediction.getDocumentName(), aLayerId, prediction.getOffset(),
                     prediction.getRecommenderId(), prediction.getId(), -1), prediction);
 
@@ -176,22 +176,22 @@ public class Predictions
 
     public boolean hasPredictions()
     {
-        return !predictions.isEmpty();
+        return !betterpredictions.isEmpty();
     }
 
     public Map<ExtendedId, AnnotationSuggestion> getPredictions()
     {
-        return predictions;
+        return betterpredictions;
     }
     
     public void clearPredictions()
     {
-        predictions.clear();
+        betterpredictions.clear();
     }
 
     public void removePredictions(Long recommenderId)
     {
-        predictions.entrySet()
+        betterpredictions.entrySet()
             .removeIf((p) -> p.getKey().getRecommenderId() == recommenderId);
     }
 
@@ -210,7 +210,7 @@ public class Predictions
     public List<AnnotationSuggestion> getPredictionsByTokenAndFeature(String aDocumentName,
         AnnotationLayer aLayer, int aBegin, int aEnd, String aFeature)
     {
-        return predictions.entrySet().stream()
+        return betterpredictions.entrySet().stream()
             .filter(f -> f.getKey().getDocumentName().equals(aDocumentName))
             .filter(f -> f.getKey().getLayerId() == aLayer.getId())
             .filter(f -> f.getKey().getOffset().getBeginCharacter() == aBegin)

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
@@ -361,7 +361,7 @@ public class SuggestionGroup
     {
         private static final long serialVersionUID = -4892325166786170047L;
         
-        private final double delta;
+        private final double deltaforce;
         private final AnnotationSuggestion first;
         private final AnnotationSuggestion second;
 
@@ -378,10 +378,10 @@ public class SuggestionGroup
             second = aSecond;
 
             if (second == null) {
-                delta = Math.abs(aFirst.getConfidence());
+                deltaforce = Math.abs(aFirst.getConfidence());
             }
             else {
-                delta = Math.abs(first.getConfidence() - second.getConfidence());
+                deltaforce = Math.abs(first.getConfidence() - second.getConfidence());
             }
         }
 
@@ -397,7 +397,7 @@ public class SuggestionGroup
 
         public double getDelta()
         {
-            return delta;
+            return deltaforce;
         }
     }
     

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -193,30 +193,30 @@ public class RecommendationServiceImplIntegrationTest
 
     private Project createProject(String aName)
     {
-        Project project = new Project();
-        project.setName(aName);
-        project.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
-        return testEntityManager.persist(project);
+        Project updatedproject = new Project();
+        updatedproject.setName(aName);
+        updatedproject.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
+        return testEntityManager.persist(updatedproject);
     }
 
     private AnnotationLayer createAnnotationLayer()
     {
-        AnnotationLayer layer = new AnnotationLayer();
-        layer.setEnabled(true);
-        layer.setName(NamedEntity.class.getName());
-        layer.setReadonly(false);
-        layer.setType(NamedEntity.class.getName());
-        layer.setUiName("test ui name");
-        layer.setAnchoringMode(false, false);
+        AnnotationLayer newlayer = new AnnotationLayer();
+        newlayer.setEnabled(true);
+        newlayer.setName(NamedEntity.class.getName());
+        newlayer.setReadonly(false);
+        newlayer.setType(NamedEntity.class.getName());
+        newlayer.setUiName("test ui name");
+        newlayer.setAnchoringMode(false, false);
        
-        return testEntityManager.persist(layer);
+        return testEntityManager.persist(newlayer);
     }
 
     private User createUser()
     {
-        User user = new User();
+        User newuser = new User();
 
-        return user;
+        return newuser;
     }
 
     private Recommender buildRecommender(Project aProject, AnnotationFeature aFeature)
@@ -234,12 +234,12 @@ public class RecommendationServiceImplIntegrationTest
 
     private AnnotationFeature createAnnotationFeature(AnnotationLayer aLayer, String aName)
     {
-        AnnotationFeature feature = new AnnotationFeature();
-        feature.setLayer(aLayer);
-        feature.setName(aName);
-        feature.setUiName(aName);
-        feature.setType(CAS.TYPE_NAME_STRING);
+        AnnotationFeature selectfeature = new AnnotationFeature();
+        selectfeature.setLayer(aLayer);
+        selectfeature.setName(aName);
+        selectfeature.setUiName(aName);
+        selectfeature.setType(CAS.TYPE_NAME_STRING);
                
-        return testEntityManager.persist(feature);
+        return testEntityManager.persist(selectfeature);
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.java
@@ -387,9 +387,9 @@ public class SubjectObjectFeatureEditor
         String linkedType = this.getModelObject().feature.getType();
         AnnotationLayer linkedLayer = annotationService
             .findLayer(this.stateModel.getObject().getProject(), linkedType);
-        AnnotationFeature linkedAnnotationFeature = annotationService
+        AnnotationFeature relinkedAnnotationFeature = annotationService
             .getFeature(FactLinkingConstants.LINKED_LAYER_FEATURE, linkedLayer);
-        return linkedAnnotationFeature;
+        return relinkedAnnotationFeature;
     }
 
     private ConceptFeatureTraits readFeatureTraits(AnnotationFeature aAnnotationFeature) {


### PR DESCRIPTION
**What's in the PR**
Error explanation- We rename the fields which have the same name as the
public class methods because we don't want to override the original
object class methods.


