### PR TITLE
[Mi12]:Remove the parentheses around the " *parameter* "

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
@@ -218,7 +218,7 @@ public class NamedEntityLinker
     private List<KBHandle> readCandidates(KnowledgeBase kb, String aCoveredText, int aBegin,
             CAS aCas)
     {
-        return kbService.read(kb, (conn) -> clService.disambiguate(kb, featureTraits.getScope(),
+        return kbService.read(kb, conn -> clService.disambiguate(kb, featureTraits.getScope(),
                 featureTraits.getAllowedValueType(), null, aCoveredText, aBegin, aCas));
     }
 

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -443,7 +443,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             String identifier = getReificationStrategy(kb).generateConceptIdentifier(conn, kb);
             aConcept.setIdentifier(identifier);
             aConcept.write(conn, kb);
@@ -486,7 +486,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier cannot be empty on update");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             conn.remove(aConcept.getOriginalStatements());
             aConcept.write(conn, kb);
         });
@@ -520,7 +520,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             String identifier = getReificationStrategy(kb).generatePropertyIdentifier(conn, kb);
             aProperty.setIdentifier(identifier);
             aProperty.write(conn, kb);
@@ -550,7 +550,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier cannot be empty on update");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             conn.remove(aProperty.getOriginalStatements());
             aProperty.write(conn, kb);
         });
@@ -594,7 +594,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             String identifier = getReificationStrategy(kb).generateInstanceIdentifier(conn, kb);
             aInstance.setIdentifier(identifier);
             aInstance.write(conn, kb);
@@ -637,7 +637,7 @@ public class KnowledgeBaseServiceImpl
             throw new IllegalArgumentException("Identifier cannot be empty on update");
         }
 
-        update(kb, (conn) -> {
+        update(kb, conn -> {
             conn.remove(aInstance.getOriginalStatements());
             aInstance.write(conn ,kb);
         });
@@ -873,7 +873,7 @@ public class KnowledgeBaseServiceImpl
      */
     public void createBaseProperty(KnowledgeBase akb, KBProperty aProperty)
     {
-        update(akb, (conn) -> {
+        update(akb, conn -> {
             aProperty.write(conn, akb);
         });
     }
@@ -954,16 +954,16 @@ public class KnowledgeBaseServiceImpl
         try (StopWatch watch = new StopWatch(log, "readItem(%s)", aIdentifier)) {
             Optional<KBConcept> kbConcept = readConcept(aKb, aIdentifier, false);
             if (kbConcept.isPresent()) {
-                return kbConcept.flatMap((c) -> Optional.of(c));
+                return kbConcept.flatMap(c -> Optional.of(c));
             }
             // In case we don't get the identifier as a concept we look for property/instance
             Optional<KBProperty> kbProperty = readProperty(aKb, aIdentifier);
             if (kbProperty.isPresent()) {
-                return kbProperty.flatMap((p) -> Optional.of(p));
+                return kbProperty.flatMap(p -> Optional.of(p));
             }
             Optional<KBInstance> kbInstance = readInstance(aKb, aIdentifier);
             if (kbInstance.isPresent()) {
-                return kbInstance.flatMap((i) -> Optional.of(i));
+                return kbInstance.flatMap(i -> Optional.of(i));
             }
             return Optional.empty();
         }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -1451,7 +1451,7 @@ public class KnowledgeBaseServiceImplIntegrationTest  {
         sut.createInstance(kb, germanInstance);
 
         // Create English instance and ensure that both have the same identifier
-        sut.update(kb, (conn) -> {
+        sut.update(kb, conn -> {
             englishInstance.setIdentifier(germanInstance.getIdentifier());
             englishInstance.write(conn, kb);
         });

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -192,7 +192,7 @@ public class Predictions
     public void removePredictions(Long recommenderId)
     {
         predictions.entrySet()
-            .removeIf((p) -> p.getKey().getRecommenderId() == recommenderId);
+            .removeIf(p -> p.getKey().getRecommenderId() == recommenderId);
     }
 
     /**

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -193,7 +193,7 @@ public class RecommenderEditorPanel
                 RecommendationEngineFactory factory = recommenderRegistry.getFactory(name);
                 return factory != null ? Pair.of(factory.getId(), factory.getName()) : null;
             }, 
-            (v) -> recommenderModel.getObject().setTool(v != null ? v.getKey() : null));
+            v -> recommenderModel.getObject().setTool(v != null ? v.getKey() : null));
 
         toolChoice = new BootstrapSelect<Pair<String, String>>(MID_TOOL, toolModel, this::listTools)
         {

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -575,7 +575,7 @@ public class RecommendationServiceImpl
     private RecommendationState getState(String aUsername, Project aProject)
     {
         synchronized (states) {
-            return states.computeIfAbsent(new RecommendationStateKey(aUsername, aProject), (v) -> 
+            return states.computeIfAbsent(new RecommendationStateKey(aUsername, aProject), v -> 
                     new RecommendationState());
         }
     }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -78,7 +78,7 @@ public class RecommendationSidebar
         IModel<Preferences> modelPreferences = LambdaModelAdapter.of(
             () -> recommendationService.getPreferences(aModel.getObject().getUser(),
                     aModel.getObject().getProject()),
-            (v) -> recommendationService.setPreferences(aModel.getObject().getUser(),
+            v -> recommendationService.setPreferences(aModel.getObject().getUser(),
                     aModel.getObject().getProject(), v));
 
         warning = new WebMarkupContainer("warning");

--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -244,7 +244,7 @@ public class ProjectsOverviewPage
     {
         User user = userRepository.getCurrentUser();
         Project currentProject = aItem.getModelObject();
-        confirmLeaveDialog.setConfirmAction((_target) -> {
+        confirmLeaveDialog.setConfirmAction(_target -> {
             projectService.listProjectPermissionLevel(user, currentProject).stream()
                     .forEach(projectService::removeProjectPermission);
             _target.add(projectListContainer);

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
@@ -94,7 +94,7 @@ public class DocumentRepositoryEditorPanel
             return listTypes().stream()
                     .filter(r -> r.getKey().equals(repositoryModel.getObject().getType()))
                     .findFirst().orElse(null);
-        }, (v) -> repositoryModel.getObject().setType(v.getKey()));
+        }, v -> repositoryModel.getObject().setType(v.getKey()));
 
         typeChoice = new BootstrapSelect<Pair<String, String>>("type", typeModel, this::listTypes)
         {

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.java
@@ -137,7 +137,7 @@ public abstract class AbstractInfoPanel<T extends KBObject> extends Panel {
             // here
             LambdaAjaxLink cancelButton = new LambdaAjaxLink("cancel",
                     AbstractInfoPanel.this::actionCancel)
-                            .onConfigure((_this) -> _this.setVisible(false));
+                            .onConfigure(_this -> _this.setVisible(false));
             cancelButton.add(new Label("label", new ResourceModel(getCancelButtonResourceKey())));
 
             LambdaAjaxButton<T> createButton = new LambdaAjaxButton<>("create",
@@ -179,7 +179,7 @@ public abstract class AbstractInfoPanel<T extends KBObject> extends Panel {
             
             // button for deleting the KBObject
             LambdaAjaxLink deleteButton = new LambdaAjaxLink("delete",
-                    AbstractInfoPanel.this::confirmActionDelete).onConfigure((_this) -> {
+                    AbstractInfoPanel.this::confirmActionDelete).onConfigure(_this -> {
                         _this.setVisible(kbObjectModel.getObject() != null
                                 && isNotEmpty(kbObjectModel.getObject().getIdentifier()));
                     });
@@ -189,7 +189,7 @@ public abstract class AbstractInfoPanel<T extends KBObject> extends Panel {
             
             // button for creating a new subclass that is only visible for concepts  
             LambdaAjaxLink createSubclassButton = new LambdaAjaxLink("createSubclass",
-                    AbstractInfoPanel.this::actionCreateSubclass).onConfigure((_this) -> {
+                    AbstractInfoPanel.this::actionCreateSubclass).onConfigure(_this -> {
                         _this.setVisible(kbObjectModel.getObject() != null
                                 && isNotEmpty(kbObjectModel.getObject().getIdentifier())
                                 && kbObjectModel.getObject() instanceof KBConcept);

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
@@ -278,7 +278,7 @@ public class QualifierFeatureEditor
     {
         AnnotationFeature linkedAnnotationFeature = getLinkedAnnotationFeature();
 
-        qualifierModel = new LambdaModelAdapter<>(() -> this.getSelectedKBItem(aItem), (v) -> {
+        qualifierModel = new LambdaModelAdapter<>(() -> this.getSelectedKBItem(aItem), v -> {
             this.setSelectedKBItem((KBHandle) v, aItem, linkedAnnotationFeature);
         });
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
@@ -450,7 +450,7 @@ public class AccessSpecificSettingsPanel
 
     private IResourceStream actionExport(String rdfFormatFileExt)
     {
-        return new TempFileResource((os) -> kbService
+        return new TempFileResource(os -> kbService
             .exportData(kbModel.getObject().getKb(), getRdfFormatForFileExt(rdfFormatFileExt), os));
     }
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementEditor.java
@@ -218,13 +218,13 @@ public class StatementEditor extends Panel
             });
             
             LambdaAjaxLink editLink = new LambdaAjaxLink("edit", StatementEditor.this::actionEdit)
-                    .onConfigure((_this) -> _this.setVisible(!statement.getObject().isInferred()));
+                    .onConfigure(_this -> _this.setVisible(!statement.getObject().isInferred()));
             editLink.add(new WriteProtectionBehavior(kbModel));
             add(editLink);
 
             LambdaAjaxLink addQualifierLink = new LambdaAjaxLink("addQualifier",
                 t -> actionAddQualifier(t, aStatement.getObject()))
-                .onConfigure((_this) -> _this.setVisible(!statement.getObject().isInferred() &&
+                .onConfigure(_this -> _this.setVisible(!statement.getObject().isInferred() &&
                     kbModel.getObject().getReification().supportsQualifier()));
             addQualifierLink.add(new Label("label", new ResourceModel("qualifier.add")));
             addQualifierLink.add(new WriteProtectionBehavior(kbModel));
@@ -232,7 +232,7 @@ public class StatementEditor extends Panel
             
             LambdaAjaxLink makeExplicitLink = new LambdaAjaxLink("makeExplicit",
                     StatementEditor.this::actionMakeExplicit).onConfigure(
-                        (_this) -> _this.setVisible(statement.getObject().isInferred()));
+                        _this -> _this.setVisible(statement.getObject().isInferred()));
             makeExplicitLink.add(new WriteProtectionBehavior(kbModel));
             add(makeExplicitLink);
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementsPanel.java
@@ -256,7 +256,7 @@ public class StatementsPanel
         }
         
         if (prefs == StatementDetailPreference.BASIC) {
-            statements.removeIf((s) -> s.isInferred());
+            statements.removeIf(s -> s.isInferred());
         }
         
         // group statements by property

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
@@ -237,13 +237,13 @@ public class StatementEditor extends Panel
             }
             add(presenter);
             LambdaAjaxLink editLink = new LambdaAjaxLink("edit", StatementEditor.this::actionEdit)
-                    .onConfigure((_this) -> _this.setVisible(!statement.getObject().isInferred()));
+                    .onConfigure(_this -> _this.setVisible(!statement.getObject().isInferred()));
             editLink.add(new WriteProtectionBehavior(kbModel));
             add(editLink);
 
             LambdaAjaxLink addQualifierLink = new LambdaAjaxLink("addQualifier",
                 t -> actionAddQualifier(t, aStatement.getObject()))
-                .onConfigure((_this) -> _this.setVisible(!statement.getObject().isInferred() &&
+                .onConfigure(_this -> _this.setVisible(!statement.getObject().isInferred() &&
                     kbModel.getObject().getReification().supportsQualifier()));
             addQualifierLink.add(new Label("label", new ResourceModel("qualifier.add")));
             addQualifierLink.add(new WriteProtectionBehavior(kbModel));
@@ -251,7 +251,7 @@ public class StatementEditor extends Panel
             
             LambdaAjaxLink makeExplicitLink = new LambdaAjaxLink("makeExplicit",
                     StatementEditor.this::actionMakeExplicit).onConfigure(
-                        (_this) -> _this.setVisible(statement.getObject().isInferred()));
+                        _this -> _this.setVisible(statement.getObject().isInferred()));
             makeExplicitLink.add(new WriteProtectionBehavior(kbModel));
             add(makeExplicitLink);
 


### PR DESCRIPTION
**What's in the PR**
Unwanted and unnecessary parentheses are removed around different parameters in the code.
In general, parentheses are used to determine any structural specifications or a particular attention towards any action on the data.
