### PR TITLE
Issue 994] restrict urls for image features

### DIFF
--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.java
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.java
@@ -69,7 +69,7 @@ public class ImageFeatureEditor
     
     private UrlValidator urlValidator()
     {
-        return new UrlValidator(new String[] { "http", "https" });
+        return new UrlValidator(new String[] { "http", "https", "ftp" });
     }
     
     @Override

--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
@@ -57,7 +57,7 @@ public class ImageFeatureSupport
     implements FeatureSupport<ImageFeatureTraits>
 {
     public static final String PREFIX = "img:";
-
+//we are going to change this part
     public static final String URL = "url";
     public static final String TYPE_IMAGE_URL = PREFIX + URL;
 

--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
@@ -57,7 +57,7 @@ public class ImageFeatureSupport
     implements FeatureSupport<ImageFeatureTraits>
 {
     public static final String PREFIX = "img:";
-//we are going to change this part...
+
     public static final String URL = "url";
     public static final String TYPE_IMAGE_URL = PREFIX + URL;
 

--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureSupport.java
@@ -57,7 +57,7 @@ public class ImageFeatureSupport
     implements FeatureSupport<ImageFeatureTraits>
 {
     public static final String PREFIX = "img:";
-//we are going to change this part
+//we are going to change this part...
     public static final String URL = "url";
     public static final String TYPE_IMAGE_URL = PREFIX + URL;
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/validators/Validators.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/validators/Validators.java
@@ -25,6 +25,6 @@ public class Validators
     public static final IValidator<String> IRI_VALIDATOR = new IriValidator();
 
     public static final UrlValidator URL_VALIDATOR = new UrlValidator(
-        new String[] { "http", "https" });
+        new String[] { "http", "https", "ftp" });
 
 }


### PR DESCRIPTION
**What's in the PR**
This PR focuses on Restricting the URLs for image features.
The enhancement is done in the module images of inception application. It would be better to limit the URLs. There is a method called URL validator that is given by apache wicket. It has regular expression patterns that restrict the URLs of images that are loaded on the browser side. we are going to use the URL validator to limit the possible URL schema, defining a regular expression for URL validation.
ISSUE : [https://github.com/inception-project/inception/issues/994](url)
**How to test manually**

- Go to Settings → Layers
- Create a new layer → Type: span
- Create a new feature → Feature details: type: Image URL

![11](https://user-images.githubusercontent.com/43853739/67637706-7bccf000-f8dd-11e9-93be-dfaa454bf7cf.jpeg)

- In the projects, you now have to open the relevant document
- Then annotate the required text with image and Image URL can be provided there.

![22](https://user-images.githubusercontent.com/43853739/67637759-07468100-f8de-11e9-985e-0e8a6599c742.jpeg)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
**Limit the possible URL schema**
The current changes made to the Pull Request fulfill this requirement.
The function 'public UrlValidator(String[] schemes)' from the package 'org.apache.wicket.validation.validator' is defined so that it validates the input URL with the defined schemes and hence we have used UrlValidator(new String[] { "http", "https", "ftp" }) to accept the respective URL schemes.

**Required that the URLs point to a particular server**
Currently it is not possible to upload images to INCEpTION. The image must only be accessed using a URL from an IIIF server and We think that limiting the user to a particular server might restrict the usability of the product.
 
**Defining a regular expression for URL validation**
We have defined a REGEX for Inception : 
((http|https|ftp)://)?[a-zA-Z]\w*(\.\w+)+(/\w*(\.\w+)*)*(|-)+(\?.+)*\.(?:png|jpg|jpeg|gif|svg)
This REGEX matches with the URL’s so that they have a particular URL scheme (In this case HTTPS, HTTP and FTP) and accepts only images with the following extensions( png, jpg, jpeg, gif and svg).

The defined REGEX matches the following URL’s as examples:

- https://farm4.staticflickr.com/3894/15008518202.c265dfa55f.h.jpg
- https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.gif
- http://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.gif
- https://farm4.staticflickr.com/3894/15008518202.c265dfa55f.h.gif
- https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.png
- http://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.png
- https://farm4.staticflickr.com/3894/15008518202.c265dfa55f.h.png
- http://upload.wikimedia.org/wikipedia/commons/b/b4/Mardin_1350660_1350692_33_images.jpg
- https://www.google.co.in/imgres?imgurl=https%3A%2F%2Fimage.flaticon.com%2Fsprites%2Fauthors%2Fsmashicons.png&imgrefurl=https%3A%2F%2Fwww.flaticon.com%2F&docid=zLriYQYIUlV7hM&tbnid=nm4EmBbTG4mWrM%3A&vet=10ahUKEwjI6L6o87TlAhXS-ioKHVAHAPQQMwh-KAEwAQ..i&w=812&h=496&bih=633&biw=1366&q=icons&ved=0ahUKEwjI6L6o87TlAhXS-ioKHVAHAPQQMwh-KAEwAQ&iact=mrc&uact=8