### PR TITLE
Add connection checker to external recommender settings

### DIFF
--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
@@ -28,9 +28,6 @@
           <div class="col-sm-9">
             <input wicket:id="remoteUrl" type="text" class="form-control"></input>
           </div>
-          <div>
-          <input type="button" wicket:id="check" class="btn btn-primary" wicket:message="value:check-connection"></input>
-          </div>
         </div>
       </div>
     </div>
@@ -45,5 +42,11 @@
       </div>  
     </div>
   </form>
+  
+  <div style="color:white" wicket:id="succesMessage">
+	</div>
+	<div style="color:white" wicket:id="feedbackMessage">
+	</div>
 </wicket:panel>
+
 </html>

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
@@ -17,7 +17,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
   xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
-<wicket:extend>
+<wicket:panel>
   <form wicket:id="form">
     <div class="form-group">
       <div class="col-sm-12 form-horizontal">
@@ -27,6 +27,9 @@
           </label>
           <div class="col-sm-9">
             <input wicket:id="remoteUrl" type="text" class="form-control"></input>
+          </div>
+          <div>
+          <input type="button" wicket:id="check" class="btn btn-primary" wicket:message="value:check-connection"></input>
           </div>
         </div>
       </div>
@@ -42,5 +45,5 @@
       </div>  
     </div>
   </form>
-</wicket:extend>
+</wicket:panel>
 </html>

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
@@ -17,24 +17,35 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
-import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import java.awt.Button;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
 
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.feedback.IFeedbackMessageFilter;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.validation.IFormValidator;
+import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
 import org.apache.wicket.validation.validator.UrlValidator;
 
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
-import de.tudarmstadt.ukp.inception.recommendation.api.recommender.DefaultTrainableRecommenderTraitsEditor;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactory;
 
 public class ExternalRecommenderTraitsEditor
-    extends DefaultTrainableRecommenderTraitsEditor
+    extends Panel
 {
     private static final long serialVersionUID = 1677442652521110324L;
 
@@ -67,15 +78,85 @@ public class ExternalRecommenderTraitsEditor
         remoteUrl.setRequired(true);
         remoteUrl.add(new UrlValidator());
         form.add(remoteUrl);
+        
+        Button applyButton = new Button("check") {
+    		private static final long serialVersionUID = 1L;
 
+    		public void onSubmit() {
+    			remoteUrl.add(new ExternalConnectionChecker());
+    		}
+
+    	};
+    	
+    	form.add((IFormValidator) applyButton);
+        
+        add(new FeedbackPanel("feedbackMessage", 
+        		new ExactErrorLevelFilter(FeedbackMessage.ERROR)).setOutputMarkupId(true));
+        add(new FeedbackPanel("succesMessage", 
+        		new ExactErrorLevelFilter(FeedbackMessage.SUCCESS)).setOutputMarkupId(true));
+        
         CheckBox trainable = new CheckBox("trainable");
-        trainable.setOutputMarkupId(true);
-        trainable.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> 
-                _target.add(getTrainingStatesChoice())));
         form.add(trainable);
-        
-        getTrainingStatesChoice().add(visibleWhen(() -> trainable.getModelObject() == true));
-        
+
         add(form);
     }
+    
+    
+    
+    
+    class ExactErrorLevelFilter implements IFeedbackMessageFilter{
+    	private int errorLevel;
+
+		public ExactErrorLevelFilter(int errorLevel){
+			this.errorLevel = errorLevel;
+		}
+
+		@Override
+		public boolean accept(FeedbackMessage message) {
+			return message.getLevel() == errorLevel;
+		}
+    }
+
+    class ExternalConnectionChecker implements IValidator<String>  {
+
+		@Override
+		public void validate(IValidatable<String> validatable){
+			String urlRecieved = validatable.getValue();
+
+			HttpURLConnection.setFollowRedirects(false);
+		    HttpURLConnection con = null;
+			try {
+				con = (HttpURLConnection) new URL(urlRecieved).openConnection();
+			} catch (MalformedURLException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		    try {
+				con.setRequestMethod("HEAD");
+			} catch (ProtocolException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+		    try {
+				if(con.getResponseCode() != 200){
+					ValidationError error = new ValidationError(this);
+					error.setVariable("statusCode", 
+							+con.getResponseCode());
+					validatable.error(error);
+				}
+			} catch (IOException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+
+		}
+
+    }	
+    
+    
+    
 }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
@@ -16,3 +16,4 @@
 
 remoteUrl=Remote URL
 trainable=Trainable
+ExternalConnectionChecker=Error in connection establishment and returned with '${statusCode}'

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
@@ -1,6 +1,6 @@
 # Copyright 2018
 # Ubiquitous Knowledge Processing (UKP) Lab
-# Technische Universität Darmstadt
+# Technische UniversitÃ¤t Darmstadt
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 remoteUrl=Remote URL
 trainable=Trainable
-ExternalConnectionChecker=Error in connection establishment and returned with '${statusCode}'
+ExternalConnectionChecker=Error code '${ErrorStatusCode}'


### PR DESCRIPTION
**What's in the PR**
We have developed a button, which when pressed checks the connection to the remote URL. After pressing the button if the connection to the URL fails, an error message will be printed. 

This pull request is based on this issue: https://github.com/inception-project/inception/issues/726
