### PR TITLE
#Issue-79-[M3][M4][M6]-[Add a private constructor to hide the implicit public one][Add the missing @deprecated Javadoc tag.][Remove this unused private method.]

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningUserStateMetaData.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningUserStateMetaData.java
@@ -21,11 +21,14 @@ import org.apache.wicket.MetaDataKey;
 
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningServiceImpl;
 
-public final class ActiveLearningUserStateMetaData
-{
+public final class ActiveLearningUserStateMetaData {
+
+	   private ActiveLearningUserStateMetaData() {
+
     public static final MetaDataKey<ActiveLearningServiceImpl.ActiveLearningUserState>
         CURRENT_AL_USER_STATE = new MetaDataKey<ActiveLearningServiceImpl.ActiveLearningUserState>()
         {
             private static final long serialVersionUID = 1L;
         };
+}
 }

--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
@@ -32,8 +32,11 @@ import org.apache.commons.lang3.builder.CompareToBuilder;
 
 import de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity;
 
-public class BaselineRankingStrategy
-{
+public final class BaselineRankingStrategy {
+
+	   private BaselineRankingStrategy() {
+
+
     private static final Comparator<CandidateEntity> INSTANCE = (e1, e2) -> new CompareToBuilder()
             // Did the user enter an URI and does the candidate exactly match it?
             // Note that the comparator sorts ascending by value, so a match is represented using
@@ -69,4 +72,5 @@ public class BaselineRankingStrategy
     {
         return INSTANCE;
     }
+}
 }

--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/util/FileUtils.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/util/FileUtils.java
@@ -39,8 +39,10 @@ import de.tudarmstadt.ukp.inception.conceptlinking.model.Property;
 /**
  * Contains utility methods to process files needed for Concept Linking
  */
-public class FileUtils
-{
+public final class FileUtils {
+
+	   private FileUtils() {
+
 
     private final static Logger log = LoggerFactory.getLogger(FileUtils.class);
 
@@ -114,4 +116,5 @@ public class FileUtils
         }
         return propertyBlacklist;
     }
+}
 }

--- a/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/HighlightUtils.java
+++ b/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/HighlightUtils.java
@@ -26,8 +26,10 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.support.annotation.OffsetSpan;
 
-public class HighlightUtils
-{
+public final class HighlightUtils {
+
+	   private HighlightUtils() {
+
     private static final Logger LOG = LoggerFactory.getLogger(HighlightUtils.class);
     
     private static final String HIGHLIGHT_START_TAG = "<em>";
@@ -66,4 +68,5 @@ public class HighlightUtils
             return Optional.empty();
         }
     }
+}
 }

--- a/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
+++ b/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
@@ -264,15 +264,6 @@ public class ExternalRecommenderIntegrationTest
         };
     }
 
-    private void createNamedEntity(CAS aCas, String aValue)
-    {
-        Type neType = getType(aCas, "de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity");
-        Feature valueFeature = neType.getFeatureByBaseName("value");
-        AnnotationFS ne = aCas.createAnnotation(neType, 0, 42);
-        ne.setStringValue(valueFeature, aValue);
-        aCas.addFsToIndexes(ne);
-    }
-
     private void addCasMetadata(JCas aJCas, long aDocumentId)
     {
         CASMetadata cmd = new CASMetadata(aJCas);

--- a/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderConformityTest.java
+++ b/inception-imls-lapps/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderConformityTest.java
@@ -136,18 +136,6 @@ public class LappsGridRecommenderConformityTest
         return casList.get(0);
     }
 
-    private static List<LappsGridService> getNerServices() throws Exception
-    {
-        Map<String, List<LappsGridService>> services = loadPredefinedServicesData();
-        return services.get("ner");
-    }
-
-    private static List<LappsGridService> getPosServices() throws Exception
-    {
-        Map<String, List<LappsGridService>> services = loadPredefinedServicesData();
-        return services.get("pos");
-    }
-
     private static Map<String, List<LappsGridService>> loadPredefinedServicesData()
             throws Exception
     {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -38,8 +38,10 @@ import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 
-public class IriConstants
-{
+public final class IriConstants {
+
+	   private IriConstants() {
+
     public static final String INCEPTION_SCHEMA_NAMESPACE = "http://www.ukp.informatik.tu-darmstadt.de/inception/schema-1.0#";
     public static final String INCEPTION_NAMESPACE = "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#";
 
@@ -144,11 +146,12 @@ public class IriConstants
                 return true;
             }
         }
-        return false;
+        return false; 
     }
 
     public static boolean isFromImplicitNamespace(KBObject handle) {
         return IMPLICIT_NAMESPACES.stream()
                 .anyMatch(ns -> handle.getIdentifier().startsWith(ns));
     }
+}
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -251,11 +251,19 @@ public class ExportedKnowledgeBase
         reification = aReification;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setSupportConceptLinking(boolean aSupportConceptLinking) {
         supportConceptLinking = aSupportConceptLinking;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public boolean isSupportConceptLinking() {
         return supportConceptLinking;

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -42,9 +42,17 @@ public class KBHandle
     private String debugInfo;
     
     // domain and range for cases in which the KBHandle represents a property
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     private String domain;
     
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     private String range;
 
@@ -78,6 +86,10 @@ public class KBHandle
         language = aLanguage;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public KBHandle(String aIdentifier, String aLabel, String aDescription, String aLanguage,
             String aDomain, String aRange)
@@ -90,24 +102,40 @@ public class KBHandle
         range = aRange;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public String getDomain()
     {
         return domain;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setDomain(String aDomain)
     {
         domain = aDomain;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public String getRange()
     {
         return range;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setRange(String aRange)
     {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Path.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Path.java
@@ -28,8 +28,10 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
 /**
  * Construct property paths for use with the {@link SparqlBuilder}
  */
-public class Path
-{
+public final class Path {
+
+	   private Path() {
+
     public static RdfPredicate of(QueryElement... aElements)
     {
         return () -> Arrays.stream(aElements)
@@ -46,4 +48,5 @@ public class Path
     {
         return () -> aElement.getQueryString() + "+";
     }
+}
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Queries.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Queries.java
@@ -32,9 +32,10 @@ import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+public final class Queries {
 
-public class Queries
-{
+	   private Queries() {
+
     private final static Logger LOG = LoggerFactory.getLogger(Queries.class);
     
     public static Map<String, KBProperty> fetchProperties(KnowledgeBase aKB,
@@ -75,4 +76,5 @@ public class Queries
                     .collect(Collectors.toMap(KBObject::getIdentifier, Function.identity()));
         }
     }
+}
 }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderAsserts.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderAsserts.java
@@ -30,8 +30,10 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 
-public class SPARQLQueryBuilderAsserts
-{
+public final class SPARQLQueryBuilderAsserts {
+
+	   private SPARQLQueryBuilderAsserts() {
+
     public static void assertThatChildrenOfExplicitRootCanBeRetrieved(KnowledgeBase aKB,
             Repository aRepository, String aRootClass)
     {
@@ -121,4 +123,5 @@ public class SPARQLQueryBuilderAsserts
             return aException;
         }
     }
+}
 }

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoRenderer.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoRenderer.java
@@ -46,8 +46,10 @@ import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.PdfExtractLine;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.Relation;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.Span;
 
-public class PdfAnnoRenderer
-{
+public final class PdfAnnoRenderer {
+
+	   private PdfAnnoRenderer() {
+
     private static final int WINDOW_SIZE_INCREMENT = 5;
 
     public static PdfAnnoModel render(AnnotatorState aState, VDocument aVDoc, String aDocumentText,
@@ -282,4 +284,5 @@ public class PdfAnnoRenderer
         return convertToDocumentOffsets(
             Arrays.asList(aOffset), aDocumentModel, aPdfExtractFile).get(0);
     }
+}
 }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
@@ -72,6 +72,10 @@ public class ExtendedId
         return projectId;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public Offset getOffset()
     {

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
@@ -107,21 +107,37 @@ public class LearningRecord
         this.user = user;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public int getOffsetTokenBegin() {
         return offsetTokenBegin;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setOffsetTokenBegin(int offsetTokenBegin) {
         this.offsetTokenBegin = offsetTokenBegin;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public int getOffsetTokenEnd() {
         return offsetTokenEnd;
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setOffsetTokenEnd(int offsetTokenEnd) {
         this.offsetTokenEnd = offsetTokenEnd;

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Offset.java
@@ -39,30 +39,50 @@ public class Offset
         return "[" + begin + "," + end + "]";
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public int getBeginCharacter()
     {
         return getBegin();
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setBeginCharacter(int beginCharacter)
     {
         setBegin(beginCharacter);
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public int getEndCharacter()
     {
         return getEnd();
     }
 
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public void setEndCharacter(int endCharacter)
     {
         setEnd(endCharacter);
     }
     
+    /**
+     * @deprecated
+     * 
+     */
     @Deprecated
     public int getStart()
     {

--- a/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/IncrementalSplitterTest.java
+++ b/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/IncrementalSplitterTest.java
@@ -34,7 +34,11 @@ import org.junit.runners.Parameterized;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
 
 @RunWith(Enclosed.class)
-public class IncrementalSplitterTest {
+public final class IncrementalSplitterTest {
+
+	   private IncrementalSplitterTest() {
+
+
 
     @RunWith(Parameterized.class)
     public static class ParameterizedTests {

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
@@ -36,8 +36,10 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 
-public class RecommendationRenderer
-{
+public final class RecommendationRenderer {
+
+	   private RecommendationRenderer() {
+
     /**
      * wrap JSON responses to BRAT visualizer
      *
@@ -92,4 +94,5 @@ public class RecommendationRenderer
         }
         return null;
     }
+}
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/RepositoryUtil.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/RepositoryUtil.java
@@ -32,7 +32,10 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * Little helper class to manage the folders used to store the results, models and recommendation
  * settings.
  */
-public class RepositoryUtil
+public final class RepositoryUtil {
+
+	   private RepositoryUtil() {
+public class 
 {
     private static final Logger logger = LoggerFactory.getLogger(RepositoryUtil.class);
 

--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -987,7 +987,7 @@ public class MtasDocumentIndex
                 sourceDocs, annotationDocs, users));
     }
 
-    private String getShortName(String aName)
+    private String aName()
     {
         String name;
 

--- a/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/ui/LinkProvider.java
+++ b/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/ui/LinkProvider.java
@@ -24,9 +24,10 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
-public class LinkProvider
+public final class LinkProvider
 {
-
+	private LinkProvider()
+	{
     /**
      * Create an external link to a page which opens a document, codes the url as
      * {@code aPageClass?params#!p=projectId&d=docId}.
@@ -41,6 +42,7 @@ public class LinkProvider
         
         return createDocumentPageLink(aProject, docId, aId, aLinkLabel, aPageClass);
     }
+}
     
     public static ExternalLink createDocumentPageLink(Project aProject, long aDocId, String aId,
             String aLinkLabel, Class<? extends WebPage> aPageClass)

--- a/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/recommendation/RecommenderTestHelper.java
+++ b/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/recommendation/RecommenderTestHelper.java
@@ -43,8 +43,10 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 
-public class RecommenderTestHelper
-{
+public final class RecommenderTestHelper
+  {
+	 private RecommenderTestHelper()
+       {
 
     public static void addScoreFeature(CAS aCas, String aTypeName, String aFeatureName)
             throws IOException, UIMAException
@@ -92,5 +94,5 @@ public class RecommenderTestHelper
                 .filter(fs -> fs.getBooleanValue(feature))
                 .collect(Collectors.toList());
     }
-
+  }
 }

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchUserStateMetaData.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchUserStateMetaData.java
@@ -18,12 +18,15 @@
 package de.tudarmstadt.ukp.inception.app.ui.externalsearch.sidebar;
 
 import org.apache.wicket.MetaDataKey;
+public final class ExternalSearchUserStateMetaData {
 
-public final class ExternalSearchUserStateMetaData
-{
+	   private ExternalSearchUserStateMetaData() {
+
+
     public static final MetaDataKey<ExternalSearchAnnotationSidebar.ExternalSearchUserState>
         CURRENT_ES_USER_STATE =
         new MetaDataKey<ExternalSearchAnnotationSidebar.ExternalSearchUserState>() {
         private static final long serialVersionUID = 1L;
     };
+}
 }

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/utils/Utilities.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/utils/Utilities.java
@@ -21,9 +21,11 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
+public final class  Utilities {
 
-public class Utilities
-{
+	   private  Utilities() {
+
+
     public static String cleanHighlight(String aHighlight) {
         Whitelist wl = new Whitelist();
         wl.addTags("em");
@@ -34,4 +36,5 @@ public class Utilities
 
         return clean.body().html();
     }
+}
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/FactLinkingConstants.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/FactLinkingConstants.java
@@ -17,8 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
-public final class FactLinkingConstants
-{
+public final class FactLinkingConstants {
+
+	   private FactLinkingConstants() {
+
+
     public static final String SUBJECT_LINK = "de.tudarmstadt.ukp.inception.api.kb.type.FactSubjectLink";
     public static final String OBJECT_LINK = "de.tudarmstadt.ukp.inception.api.kb.type.FactObjectLink";
     public static final String QUALIFIER_LINK = "de.tudarmstadt.ukp.inception.api.kb.type.FactQualifierLink";
@@ -30,4 +33,5 @@ public final class FactLinkingConstants
 
     //identifier here is a feature of the NamedEntity layer
     public static final String LINKED_LAYER_FEATURE = "identifier";
+}
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/validators/Validators.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/validators/Validators.java
@@ -20,11 +20,14 @@ package de.tudarmstadt.ukp.inception.ui.kb.project.validators;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.validator.UrlValidator;
 
-public class Validators
-{
+public final class Validators {
+
+	   private Validators() {
+
     public static final IValidator<String> IRI_VALIDATOR = new IriValidator();
 
     public static final UrlValidator URL_VALIDATOR = new UrlValidator(
         new String[] { "http", "https" });
 
+}
 }


### PR DESCRIPTION
**What's in the PR**

**M3-Add a private constructor to hide the implicit public one**
The utility classes are better utilized when declared final and each individual private constructor is defined. This reduces the effort of a parameterless constructor which could be used elsewhere in the code. Making the class final is not only a good practice but also eliminates the usage of these utility classes in other subclasses. However, private constructors would always be able to extend themselves to other classes.

**M4-Add the missing @deprecated Javadoc tag.**
The packages in any Java code are created as a namespace. And these namespaces contain various elements such as classes, interfaces, methods, and functions. One cannot reduce or deprecate a package as it has unknown implications. But one can always remove the public classes and methods which won't be used anymore giving the modern tools (IDE's) to notify the users or developers that there is no such field or class.

**M6-Remove this unused private method**
Both inefficient usages of memory and power are considered a bad practice in software development. Similarly, the unused private methods in the code are only a burden to the size of the code. As they are never executed it is a good practice to remove them totally leading to a better understanding of the code and increase in maintainability.